### PR TITLE
Log PagerdutyV2 body on HTTP 400 errors

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -553,7 +553,7 @@ func (n *PagerDuty) notifyV2(
 	}
 	defer resp.Body.Close()
 
-	return n.retryV2(resp.StatusCode)
+	return n.retryV2(resp)
 }
 
 // Notify implements the Notifier interface.
@@ -621,10 +621,20 @@ func (n *PagerDuty) retryV1(resp *http.Response) (bool, error) {
 	return false, nil
 }
 
-func (n *PagerDuty) retryV2(statusCode int) (bool, error) {
+func (n *PagerDuty) retryV2(resp *http.Response) (bool, error) {
 	// Retrying can solve the issue on 429 (rate limiting) and 5xx response codes.
 	// 2xx response codes indicate a successful request.
 	// https://v2.developer.pagerduty.com/docs/events-api-v2#api-response-codes--retry-logic
+	statusCode := resp.StatusCode
+
+	if statusCode == 400 && resp.Body != nil {
+		bs, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, fmt.Errorf("unexpected status code %v : problem reading response: %v", statusCode, err)
+		}
+		return false, fmt.Errorf("bad request (status code %v): %v", statusCode, string(bs))
+	}
+
 	if statusCode/100 != 2 {
 		return (statusCode == 429 || statusCode/100 == 5), fmt.Errorf("unexpected status code %v", statusCode)
 	}

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -61,7 +61,10 @@ func TestPagerDutyRetryV2(t *testing.T) {
 
 	retryCodes := append(defaultRetryCodes(), http.StatusTooManyRequests)
 	for statusCode, expected := range retryTests(retryCodes) {
-		actual, _ := notifier.retryV2(statusCode)
+		resp := &http.Response{
+			StatusCode: statusCode,
+		}
+		actual, _ := notifier.retryV2(resp)
 		require.Equal(t, expected, actual, fmt.Sprintf("retryv2 - error on status %d", statusCode))
 	}
 }


### PR DESCRIPTION
Applies https://github.com/prometheus/alertmanager/pull/1481 to the Pagerduty V2 retry path